### PR TITLE
Improve error handling when Ajax request fails

### DIFF
--- a/webroot/js/lib/app.js
+++ b/webroot/js/lib/app.js
@@ -174,7 +174,17 @@ Frontend.App = Class.extend({
 			},
 			error: function(jqXHR, textStatus, errorThrown) {
 				var responseText = jqXHR.responseText;
-				var response = $.parseJSON(responseText);
+				var response = null;
+				try {
+					response = $.parseJSON(responseText);
+				} catch (exception) {
+					response = {
+						code: 'error',
+						exception: exception,
+						requestData: requestData,
+						responseText: responseText
+					};
+				}
 				if (typeof response != 'object') {
 					response = {
 						code: 'error',


### PR DESCRIPTION
When the request fails and the responseText is not parseable the current implementation fails.
This prevents complete failure when the responseText is not parseable.