### PR TITLE
Fix redirect routing

### DIFF
--- a/src/Lib/FrontendBridgeTrait.php
+++ b/src/Lib/FrontendBridgeTrait.php
@@ -86,15 +86,7 @@ trait FrontendBridgeTrait
     protected function redirectJsonAction($url)
     {
         if (is_array($url)) {
-            // collect the pass parameters of the url under "pass" key for JS-router compatibility
-            $pass = [];
-            foreach ($url as $key => $value) {
-                if (is_int($key)) {
-                    $pass[$key] = $value;
-                    unset($url[$key]);
-                }
-            }
-            $url['pass'] = $pass;
+            $url = $this->prepareUrl($url);
         }
         $response = [
             'code' => 'success',
@@ -103,5 +95,26 @@ trait FrontendBridgeTrait
             ]
         ];
         return new ServiceResponse($response);
+    }
+
+    /**
+     * Prepare a url array for the JS router
+     *
+     * @param  array $url a standard CakePHP url array
+     * @return array
+     */
+    private function prepareUrl(array $url): array
+    {
+        // collect the pass parameters of the url under "pass" key for router.js compatibility
+        $pass = [];
+        foreach ($url as $key => $value) {
+            if (is_int($key)) {
+                $pass[$key] = $value;
+                unset($url[$key]);
+            }
+        }
+        $url['pass'] = $pass;
+
+        return $url;
     }
 }

--- a/src/Lib/FrontendBridgeTrait.php
+++ b/src/Lib/FrontendBridgeTrait.php
@@ -1,6 +1,8 @@
 <?php
 namespace FrontendBridge\Lib;
 
+use FrontendBridge\Lib\ServiceResponse;
+
 trait FrontendBridgeTrait
 {
     /**
@@ -23,7 +25,7 @@ trait FrontendBridgeTrait
             ]
         ];
 
-        return new \FrontendBridge\Lib\ServiceResponse($response);
+        return new ServiceResponse($response);
     }
 
     /**
@@ -78,18 +80,28 @@ trait FrontendBridgeTrait
     /**
      * Json action redirect
      *
-     * @param  string  $url  URL
+     * @param  array|string  $url  URL
      * @return \FrontendBridge\Lib\ServiceResponse
      */
     protected function redirectJsonAction($url)
     {
+        if (is_array($url)) {
+            // collect the pass parameters of the url under "pass" key for JS-router compatibility
+            $pass = [];
+            foreach ($url as $key => $value) {
+                if (is_int($key)) {
+                    $pass[$key] = $value;
+                    unset($url[$key]);
+                }
+            }
+            $url['pass'] = $pass;
+        }
         $response = [
             'code' => 'success',
             'data' => [
                 'redirect' => $url
             ]
         ];
-
-        return new \FrontendBridge\Lib\ServiceResponse($response);
+        return new ServiceResponse($response);
     }
 }

--- a/webroot/js/lib/router.js
+++ b/webroot/js/lib/router.js
@@ -37,17 +37,17 @@ Frontend.Router = Class.extend({
      * @param string    action       The controller action
      * @param Array     pass         An array containing the pass params (/arg1/arg2/)
      * @param Object    query        An object containing the named params, indexed by param name
-     * @param string    string       The hash to append to the url
+     * @param string    anchor       The anchor to append to the url
      * @return string                The generated URL
      */
-    url: function(controller, action, pass, query, hash) {
+    url: function(controller, action, pass, query, anchor) {
         if (typeof controller == 'object') {
             var params = jQuery.extend({}, this.urlDefaults, controller);
             controller = params.controller;
             action = params.action;
             pass = params.pass;
             query = params.query;
-            hash = params['#'];
+            anchor = params['#'];
             var prefix = params.prefix;
             var plugin = params.plugin;
         }
@@ -72,8 +72,8 @@ Frontend.Router = Class.extend({
             url += '?' + http_build_query(query);
         }
 
-        if (hash) {
-            url += '#' + hash;
+        if (anchor) {
+            url += '#' + anchor;
         }
 
         return url;

--- a/webroot/js/lib/router.js
+++ b/webroot/js/lib/router.js
@@ -61,7 +61,7 @@ Frontend.Router = Class.extend({
             $.each(pass, function (i, val) {
                 url += val + '/';
             });
-            // remove last "/" from url to not disturb functionality of possible #-anchor in url
+            // remove "/" from end to not disturb functionality of possible #-anchor in url
             url = url.slice(0, -1);
         }
 

--- a/webroot/js/lib/router.js
+++ b/webroot/js/lib/router.js
@@ -10,7 +10,8 @@ Frontend.Router = Class.extend({
         pass: [],
         query: {},
         prefix: '',
-        plugin: null
+        plugin: null,
+        '#': null,
     },
     /**
      * Class constructor
@@ -32,20 +33,22 @@ Frontend.Router = Class.extend({
      * and action keys (see this.urlDefaults). Otherwise it takes
      * the function arguments.
      *
-     * @param string    controller     The controller name in lower case
-     * @param string    action         The controller action
-     * @param Array        pass        An array containing the pass params (/arg1/arg2/)
-     * @param Object     query        An object containing the named params, indexed by param name
+     * @param string    controller   The controller name in lower case
+     * @param string    action       The controller action
+     * @param Array     pass         An array containing the pass params (/arg1/arg2/)
+     * @param Object    query        An object containing the named params, indexed by param name
+     * @param string    string       The hash to append to the url
      * @return string                The generated URL
      */
-    url: function(controller, action, pass, query) {
+    url: function(controller, action, pass, query, hash) {
         if (typeof controller == 'object') {
             var params = jQuery.extend({}, this.urlDefaults, controller);
-            var controller = params.controller;
-            var action = params.action;
-            var pass = params.pass;
+            controller = params.controller;
+            action = params.action;
+            pass = params.pass;
+            query = params.query;
+            hash = params['#'];
             var prefix = params.prefix;
-            var query = params.query;
             var plugin = params.plugin;
         }
 
@@ -68,6 +71,11 @@ Frontend.Router = Class.extend({
         if (typeof query == 'object' && !$.isEmptyObject(query)) {
             url += '?' + http_build_query(query);
         }
+
+        if (hash) {
+            url += '#' + hash;
+        }
+
         return url;
     },
     /**

--- a/webroot/js/lib/router.js
+++ b/webroot/js/lib/router.js
@@ -57,13 +57,15 @@ Frontend.Router = Class.extend({
 
         var url = this.webroot + prefix + plugin + controller + '/' + action + '/';
 
-        if (pass instanceof Array) {
+        if (pass instanceof Array && pass.length > 0) {
             $.each(pass, function (i, val) {
                 url += val + '/';
             });
+            // remove last "/" from url to not disturb functionality of possible #-anchor in url
+            url = url.slice(0, -1);
         }
 
-        if (typeof query == 'object') {
+        if (typeof query == 'object' && !$.isEmptyObject(query)) {
             url += '?' + http_build_query(query);
         }
         return url;


### PR DESCRIPTION
url pass parameters were not detected when redirecting in a json request, because the router.js lib expected them to be under the key "pass", so I restructure the url array in the FBTrait.

Also, the need arose to give an additional anchor part in the redirect (like `#tab1`). But because the router.js does not support this at all, I added checks into it so it does not always append `/` at the end and `?` if there are no query parameter. That way, anchors work.
The only shortcoming with this is, that you can't give the url in the standard cakePHP way but rather have to concat the anchor to the last passed parameter in the redirect in the php controller, like so:

```
return $this->redirect([
    'controller' => 'Foo',
    'action' => 'foo',
    $someId,
    $lastId . '#tab1'
]);
```

For the router to support the standard url array with `'#' => 'tab1`, additional adjustments to the router.js would be necessary. But I wanted to hear your opinions on that first.

Thanks