### PR TITLE
Fix loader not showing on form submit

### DIFF
--- a/webroot/js/lib/dialog.js
+++ b/webroot/js/lib/dialog.js
@@ -218,7 +218,6 @@ Frontend.Dialog = Class.extend({
                 data: formData,
                 preventHistory: true
             });
-            App.Main.UIBlocker.unblockElement($(this._getBlockElement()));
         }.bind(this));
 
         if (this._history.entries.length > 0) {


### PR DESCRIPTION
Because the loader is unblocked directly after being blocked and not after the ajax request is done it is never shown.
As the loader is automatically removed after the submit we can safely remove it here.