### PR TITLE
Add back button function to helper

### DIFF
--- a/src/Lib/FrontendBridgeTrait.php
+++ b/src/Lib/FrontendBridgeTrait.php
@@ -56,7 +56,7 @@ trait FrontendBridgeTrait
      * @param string $layout the layout path
      * @return string
      */
-    protected function getLayout(?string $layout): string
+    protected function getLayout(string $layout = null): string
     {
         if ($layout === null) {
             $frontendBridgeComponentExists = isset($this->FrontendBridge);

--- a/src/View/Helper/FrontendBridgeHelper.php
+++ b/src/View/Helper/FrontendBridgeHelper.php
@@ -460,12 +460,28 @@ class FrontendBridgeHelper extends Helper
     }
 
     /**
+     * Get the back button for modal dialogs if dialog_header is not used
+     *
+     * @param  string $title optional title of the button, default is translation of "back"
+     * @return string        HTML
+     */
+    public function dialogBackButton(string $title = null): string
+    {
+        $button = '<button class="modal-back btn btn-primary">';
+        $button .= '<i class="fa fa-fw fa-arrow-left"></i>';
+        $button .= $title ?? __('dialog.back');
+        $button .= '</button>';
+
+        return $button;
+    }
+
+    /**
      * Add a file to the frontend dependencies
      *
      * @param string $file path to be added
      * @return void
      */
-    protected function _addDependency($file): void
+    protected function _addDependency(string $file): void
     {
         $file = str_replace('\\', '/', $file);
         if (!in_array($file, $this->_dependencies)) {


### PR DESCRIPTION
For the case that your modal has no dialog_header but you still want the back button to navigate through the modal history, we got you covered now!

Simply Include this function anywhere in your content (view file getting rendered by the ajax call) or even the dialog_footer and you are ready to go.