### PR TITLE
Fix configuration not being passed to new dialog

### DIFF
--- a/webroot/js/lib/dialog.js
+++ b/webroot/js/lib/dialog.js
@@ -257,10 +257,14 @@ Frontend.Dialog = Class.extend({
                 formData = $target.serialize();
             }
 
-            this.loadDialog(url, {
+            var config = this._config;
+            
+            jQuery.extend(config, {
                 data: formData,
                 preventHistory: true
             });
+
+            this.loadDialog(url, config);
         }.bind(this));
 
         if (this._history.entries.length > 0) {


### PR DESCRIPTION
This passes the configuration to the new dialog that is being loaded so that `onDialogClose` callbacks still work.