### PR TITLE
Fix some browsers reloading the current page

### DIFF
--- a/webroot/js/lib/dialog.js
+++ b/webroot/js/lib/dialog.js
@@ -68,7 +68,9 @@ Frontend.Dialog = Class.extend({
 
                     window.location = redirectUrl;
                     // Force reloading for urls containing an anchor
-                    window.location.reload(true);
+                    if (redirectUrl.indexOf('#') !== -1) {
+                        window.location.reload(true);
+                    }
                     return
                 }
                 // Error handling


### PR DESCRIPTION
Some browsers do not follow the javascript standard correctly and reload the current page instead of the page that is set in window.location.